### PR TITLE
refactor state management

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { ConversationList } from '@/components/conversation-list';
 import { Form } from '@/components/form';
 import { conversationsAtom, selectedDayAtom } from '@/lib/atom';
 import { format, fromUnixTime } from 'date-fns';
-import { useAtomValue } from 'jotai';
+import { atom, useAtomValue } from 'jotai';
 import Link from 'next/link';
 import * as React from 'react';
 
@@ -17,6 +17,12 @@ function filterConversationsByDay(conversations: Conversation[], day: string): C
 		return formattedDate === day;
 	});
 }
+
+const conversationsByDayAtom = atom((get) => {
+	const conversations = get(conversationsAtom);
+	const selectedDay = get(selectedDayAtom);
+	return conversations != null && selectedDay != null ? filterConversationsByDay(conversations, selectedDay) : [];
+});
 
 function Head() {
 	return (
@@ -32,8 +38,7 @@ function Head() {
 export default function AIAnalytics() {
 	const conversations = useAtomValue(conversationsAtom);
 	const selectedDay = useAtomValue(selectedDayAtom);
-
-	const filteredConversations = conversations != null && selectedDay != null ? filterConversationsByDay(conversations, selectedDay) : [];
+	const filteredConversations = useAtomValue(conversationsByDayAtom);
 
 	return (
 		<div className="min-h-screen bg-black p-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,11 @@
 'use client';
 
-import type { Conversation } from '@/lib/schema';
 import { ActivityHeatmap } from '@/components/activity-heatmap';
 import { ConversationList } from '@/components/conversation-list';
 import { Form } from '@/components/form';
 import { conversationsAtom, selectedDayAtom } from '@/lib/atom';
-import { format, fromUnixTime } from 'date-fns';
-import { atom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import Link from 'next/link';
-import * as React from 'react';
-
-function filterConversationsByDay(conversations: Conversation[], day: string): Conversation[] {
-	return conversations.filter((conversation) => {
-		const date = fromUnixTime(conversation.create_time);
-		const formattedDate = format(date, 'yyyy-MM-dd');
-		return formattedDate === day;
-	});
-}
-
-const conversationsByDayAtom = atom((get) => {
-	const conversations = get(conversationsAtom);
-	const selectedDay = get(selectedDayAtom);
-	return conversations != null && selectedDay != null ? filterConversationsByDay(conversations, selectedDay) : [];
-});
 
 function Head() {
 	return (
@@ -38,7 +21,6 @@ function Head() {
 export default function AIAnalytics() {
 	const conversations = useAtomValue(conversationsAtom);
 	const selectedDay = useAtomValue(selectedDayAtom);
-	const filteredConversations = useAtomValue(conversationsByDayAtom);
 
 	return (
 		<div className="min-h-screen bg-black p-8">
@@ -75,16 +57,13 @@ export default function AIAnalytics() {
 				{
 					// eslint-disable-next-line ts/strict-boolean-expressions
 					conversations && (
-						<ActivityHeatmap conversations={conversations} />
+						<ActivityHeatmap />
 					)
 				}
 				{
 					// eslint-disable-next-line ts/strict-boolean-expressions
 					conversations && selectedDay && (
-						<ConversationList
-							date={selectedDay ?? ''}
-							conversations={filteredConversations}
-						/>
+						<ConversationList />
 					)
 				}
 			</div>

--- a/lib/atom.ts
+++ b/lib/atom.ts
@@ -1,6 +1,13 @@
 import type { Conversation } from './schema';
 import { atom } from 'jotai';
+import { filterConversationsByDay } from './utils';
+
+export const selectedDayAtom = atom<string | null>(null);
 
 export const conversationsAtom = atom<Conversation[]>();
 
-export const selectedDayAtom = atom<string | null>(null);
+export const conversationsByDayAtom = atom((get) => {
+	const conversations = get(conversationsAtom);
+	const selectedDay = get(selectedDayAtom);
+	return conversations != null && selectedDay != null ? filterConversationsByDay(conversations, selectedDay) : [];
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,16 @@
+import type { Conversation } from './schema';
 import { type ClassValue, clsx } from 'clsx';
+import { format, fromUnixTime } from 'date-fns';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
+}
+
+export function filterConversationsByDay(conversations: Conversation[], day: string): Conversation[] {
+	return conversations.filter((conversation) => {
+		const date = fromUnixTime(conversation.create_time);
+		const formattedDate = format(date, 'yyyy-MM-dd');
+		return formattedDate === day;
+	});
 }


### PR DESCRIPTION
Move the filtering logic for conversations by day into a derived atom to
better separate concerns and improve code organization. This change
leverages Jotai's derived atom pattern for more efficient state
management.
This pull request refactors the `AIAnalytics` page and its associated components to use Jotai atoms for state management, improving code modularity and readability. The most important changes include the removal of redundant code, the introduction of new atoms, and the refactoring of component props.

### Refactoring and State Management Improvements:

* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L3-L19): Removed the `filterConversationsByDay` function and the `filteredConversations` variable, and updated the `ActivityHeatmap` and `ConversationList` components to no longer require props. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L3-L19) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L36-L37) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L73-R66)
* [`components/activity-heatmap.tsx`](diffhunk://#diff-1480bff03d30d008c2284f3f05206b957479b690ea67abaa2a51890f9d20c940L3-R54): Replaced the `conversations` prop with Jotai atoms to manage state internally, including new atoms for activities and total conversations. [[1]](diffhunk://#diff-1480bff03d30d008c2284f3f05206b957479b690ea67abaa2a51890f9d20c940L3-R54) [[2]](diffhunk://#diff-1480bff03d30d008c2284f3f05206b957479b690ea67abaa2a51890f9d20c940L128-R139)
* [`components/conversation-list.tsx`](diffhunk://#diff-274f519da54c482d20392246891dd48e2cff32ed3734fe8ab6894f9f59ebdf97R3-R46): Refactored to use Jotai atoms for managing conversations and their counts, removing the need for props and the `useConversationCounts` hook. [[1]](diffhunk://#diff-274f519da54c482d20392246891dd48e2cff32ed3734fe8ab6894f9f59ebdf97R3-R46) [[2]](diffhunk://#diff-274f519da54c482d20392246891dd48e2cff32ed3734fe8ab6894f9f59ebdf97L50-L76) [[3]](diffhunk://#diff-274f519da54c482d20392246891dd48e2cff32ed3734fe8ab6894f9f59ebdf97L125-R116) [[4]](diffhunk://#diff-274f519da54c482d20392246891dd48e2cff32ed3734fe8ab6894f9f59ebdf97L138-R136)

### New Atom Definitions:

* [`lib/atom.ts`](diffhunk://#diff-e0cdd001e15fa677dc29db33db7f581153388527671e16d61e7c59e9e1ab1ecfR3-R13): Added new atoms `conversationsByDayAtom` and refactored `selectedDayAtom` and `conversationsAtom` to use `filterConversationsByDay` from the `utils` module.
* [`lib/utils.ts`](diffhunk://#diff-98e56006aa8453a29bc2b8bc8e6f718b3f17ba66470f3a52a5dc5bd643482e70R1-R16): Moved the `filterConversationsByDay` function here for reuse across different modules.